### PR TITLE
Fix warning and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Precompiled 3D-printable example in [demo_nutAndBolt.stl](demo_nutAndBolt.stl)
 
 **Existing standards are not a focus and not provided here since:**  
 
-* Existing standards (metric, imperial, …) are not and where never meant for FDM printing (with its peculiar design constraints)  
+* Existing standards (metric, imperial, …) are not and were never meant for FDM printing (with its peculiar design constraints)  
 * OpenSCAD libraries for existing standards do exist <br> (references at the very end)  
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -150,10 +150,6 @@ and the standard FDM nozzel diamater is about 0.4mm)
 The planned solution:   
 Designing of a dedicated cliplock for these kinds of low-pitched screws.  
 
-# Known specific issues
-
-WARNING: Too many unnamed arguments supplied, in file lib-FDMscrews.scad, line 217  
-
 ## Other screw-libraries for existing standards (none are meant for FDM printing)
 
 To my knowledge there are no screw standards that where 

--- a/lib-FDMscrews.scad
+++ b/lib-FDMscrews.scad
@@ -214,7 +214,7 @@ module screw_internal
   // i[2] ... cylindercoord evaluation height for user supplied function
   preevalpoints =
     [ for(i=evalparams)
-      concat( i[0]*profileradiusfunction(starts*i[1]+offsetangle+360,i[2]), i[2] ) ];
+      concat( i[0]*profileradiusfunction(starts*i[1]+offsetangle+360), i[2] ) ];
     
   translate([0,0,0])
     polyhedron(points = concat(preevalpoints,[[0,0,0],[0,0,z_max]]),faces = evalindices,convexity =3);


### PR DESCRIPTION
The warning was coming from the fact that `profileradiusfunction` takes only one parameter but was given two. Removing the second parameter fixes it and should have no effect (AFAIU the second parameter was ignored).